### PR TITLE
Fix incorrect usage of %-formatting

### DIFF
--- a/scripts/bib4txt.py
+++ b/scripts/bib4txt.py
@@ -173,20 +173,20 @@ def main():
     parser.add_argument("-o", "--outfile", action="store", dest="outfile",
                       help="Write formatted references to FILE", metavar="FILE")
     parser.add_argument("-n", "--nuke", action="store_true", dest="overwrite", default=False,
-                      help="silently overwrite outfile, default=%default")
+                      help="silently overwrite outfile, default=%(default)s")
     parser.add_argument("-F", "--stylefile", action="store",
                       dest="stylefile", default="default.py",
                       help="Specify user-chosen style file",metavar="FILE")
     parser.add_argument("-s", "--style", action="store", 
                       dest="style", default="default",
                       help="Specify user-chosen style (by style name).")
-    #parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False, help="Print INFO messages to stdout, default=%default")
+    #parser.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False, help="Print INFO messages to stdout, default=%(default)s")
     parser.add_argument("-V", "--verbosity", action="store", type=int, dest="verbosity", default=0,
-                      help="2: print DEBUG messages; 1: print INFO messages; default=%default")
+                      help="2: print DEBUG messages; 1: print INFO messages; default=%(default)s")
     parser.add_argument("-a", "--all", action="store_true", dest="entire_doc", default=False,
-                      help="Output entire document, making citation reference substitutions, default=%default")
+                      help="Output entire document, making citation reference substitutions, default=%(default)s")
     parser.add_argument("-x", "--xp", action="store_true", dest="xp_parse",
-                      default=False, help="Use experimental document parser, default=%default")
+                      default=False, help="Use experimental document parser, default=%(default)s")
     parser.add_argument("-L", "--logger-level", action="store", type=int, dest="logger_level",
                       help="Set logging level to integer value.")
     parser.add_argument("bibfiles", action="store", nargs='*',


### PR DESCRIPTION
Without this patch, calling bib4txt with `--help` failed.  The issue might exist in other scripts.

```
python2 /build/bibstuff/scripts/bib4txt.py -h
Traceback (most recent call last):
  File "/build/bibstuff/scripts/bib4txt.py", line 289, in <module>
    main()
  File "/build/bibstuff/scripts/bib4txt.py", line 195, in main
    args = parser.parse_args()
  File "/usr/lib/python2.7/argparse.py", line 1705, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1737, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1943, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python2.7/argparse.py", line 1883, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python2.7/argparse.py", line 1811, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python2.7/argparse.py", line 1000, in __call__
    parser.print_help()
  File "/usr/lib/python2.7/argparse.py", line 2344, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/lib/python2.7/argparse.py", line 2318, in format_help
    return formatter.format_help()
  File "/usr/lib/python2.7/argparse.py", line 281, in format_help
    help = self._root_section.format_help()
  File "/usr/lib/python2.7/argparse.py", line 211, in format_help
    func(*args)
  File "/usr/lib/python2.7/argparse.py", line 211, in format_help
    func(*args)
  File "/usr/lib/python2.7/argparse.py", line 521, in _format_action
    help_text = self._expand_help(action)
  File "/usr/lib/python2.7/argparse.py", line 607, in _expand_help
    return self._get_help_string(action) % params
TypeError: %d format: a number is required, not dict
```

I had to run with Python 2 because the code mentions `basestring`, which isn't in Python 3.
